### PR TITLE
Add pageload event filtering option to configuration

### DIFF
--- a/configs/impact-of-race-cache-with-network-nightly_has_ssd_false.json
+++ b/configs/impact-of-race-cache-with-network-nightly_has_ssd_false.json
@@ -1,0 +1,20 @@
+{
+  "slug": "impact-of-race-cache-with-network-nightly",
+
+  "histograms": [
+  ],
+
+  "pageload_event_metrics": {
+    "dns_lookup_time" : [0, 30000],
+    "time_to_request_start" : [0, 30000],
+    "fcp_time" : [0, 30000],
+    "load_time": [0, 30000],
+    "lcp_time": [0, 30000]
+  },
+
+  "pageload_event_filter": "(SELECT value FROM UNNEST(event.extra) WHERE key = 'has_ssd') = 'false'",
+
+  "segments": [
+    "Windows"
+  ]
+}

--- a/lib/telemetry.py
+++ b/lib/telemetry.py
@@ -241,7 +241,8 @@ class TelemetryClient:
         "minVal": minVal,
         "maxVal": maxVal,
         "metric": metric,
-        "branches": branches
+        "branches": branches,
+        "pageload_event_filter": self.config.get('pageload_event_filter')
     }
 
     query = t.render(context)
@@ -275,7 +276,8 @@ class TelemetryClient:
         "startDate": self.config['startDate'],
         "endDate": self.config['endDate'],
         "metric": metric,
-        "blacklist": isp_blacklist
+        "blacklist": isp_blacklist,
+        "pageload_event_filter": self.config.get('pageload_event_filter')
     }
     query = t.render(context)
     # Remove empty lines before returning

--- a/lib/templates/sql/archived/events_generic.sql
+++ b/lib/templates/sql/archived/events_generic.sql
@@ -27,6 +27,9 @@ WHERE
 {% for condition in segment.conditions %}
   {{condition}}
 {% endfor %}
+{% if pageload_event_filter %}
+  AND {{pageload_event_filter}}
+{% endif %}
 ),
 aggregated_{{segment.name}} as (
 SELECT

--- a/lib/templates/sql/archived/events_no_segments.sql
+++ b/lib/templates/sql/archived/events_no_segments.sql
@@ -24,6 +24,9 @@ WHERE
 {% if segmentConditions %}
   {{segmentConditions}}
 {% endif %}
+{% if pageload_event_filter %}
+  AND {{pageload_event_filter}}
+{% endif %}
 )
 SELECT
   bucket,

--- a/lib/templates/sql/archived/events_os_segments_non_experiment_with_android.sql
+++ b/lib/templates/sql/archived/events_os_segments_non_experiment_with_android.sql
@@ -19,6 +19,9 @@ eventdata_{{branch.name}}_desktop as (
 {% for condition in branch.glean_conditions %}
         {{condition}}
 {% endfor %}
+{% if pageload_event_filter %}
+        AND {{pageload_event_filter}}
+{% endif %}
 ),
 aggregate_{{branch.name}}_desktop as (
 SELECT
@@ -52,6 +55,9 @@ eventdata_{{branch.name}}_android as (
 {% for condition in branch.glean_conditions %}
         {{condition}}
 {% endfor %}
+{% if pageload_event_filter %}
+        AND {{pageload_event_filter}}
+{% endif %}
 ),
 aggregate_{{branch.name}}_android as (
 SELECT

--- a/lib/templates/sql/experiment/glean/pageload_events_os_segments.sql
+++ b/lib/templates/sql/experiment/glean/pageload_events_os_segments.sql
@@ -16,6 +16,9 @@ WHERE
   {% for isp in blacklist %}
   AND metadata.isp.name != "{{isp}}"
   {% endfor %}
+  {% if pageload_event_filter %}
+  AND {{pageload_event_filter}}
+  {% endif %}
 )
 {% if include_non_enrolled_branch == True %}
 ,
@@ -33,6 +36,9 @@ WHERE
   AND DATE(submission_timestamp) >= DATE('{{startDate}}')
   AND DATE(submission_timestamp) <= DATE('{{endDate}}')
   AND ARRAY_LENGTH(ping_info.experiments) = 0
+  {% if pageload_event_filter %}
+  AND {{pageload_event_filter}}
+  {% endif %}
 )
 {% endif %}
 , android_eventdata as (
@@ -52,6 +58,9 @@ WHERE
   {% for isp in blacklist %}
   AND metadata.isp.name != "{{isp}}"
   {% endfor %}
+  {% if pageload_event_filter %}
+  AND {{pageload_event_filter}}
+  {% endif %}
 )
 {% if include_non_enrolled_branch == True %}
 ,
@@ -69,6 +78,9 @@ WHERE
   AND DATE(submission_timestamp) >= DATE('{{startDate}}')
   AND DATE(submission_timestamp) <= DATE('{{endDate}}')
   AND ARRAY_LENGTH(ping_info.experiments) = 0
+  {% if pageload_event_filter %}
+  AND {{pageload_event_filter}}
+  {% endif %}
 )
 {% endif %}
 

--- a/lib/templates/sql/other/glean/pageload_events_os_segments.sql
+++ b/lib/templates/sql/other/glean/pageload_events_os_segments.sql
@@ -22,6 +22,9 @@ eventdata_{{branch.name}}_desktop as (
         {% for isp in blacklist %}
         AND metadata.isp.name != "{{isp}}"
         {% endfor %}
+        {% if pageload_event_filter %}
+        AND {{pageload_event_filter}}
+        {% endif %}
 ),
 eventdata_{{branch.name}}_android as (
     SELECT
@@ -43,6 +46,9 @@ eventdata_{{branch.name}}_android as (
         {% for isp in blacklist %}
         AND metadata.isp.name != "{{isp}}"
         {% endfor %}
+        {% if pageload_event_filter %}
+        AND {{pageload_event_filter}}
+        {% endif %}
 ),
 aggregate_{{branch.name}}_desktop as (
 SELECT


### PR DESCRIPTION
@dpalmeiro let me know if you think this is a good way of adding filtering to the report configuration and generation.

It does add some SQL to the config, but it's also pretty useful.

A more complicated alternative could be to make new segments, defined by filters?

